### PR TITLE
Added instance_url and refresh_token to credentials hash.

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -35,6 +35,13 @@ module OmniAuth
         }
       end
 
+      credentials do
+        hash = {'token' => access_token.token}
+        hash.merge!('instance_url' => access_token.params["instance_url"])
+        hash.merge!('refresh_token' => access_token.refresh_token) if access_token.refresh_token
+        hash
+      end
+
       def raw_info
         access_token.options[:mode] = :query
         access_token.options[:param_name] = :oauth_token


### PR DESCRIPTION
salesforce does not have an expiration date on the refresh token - so OmniAuth gem does not set that property from the auth hash.

Thanks you for this strategy.  We're using it just fine now but It wouldn't work without the instance_url in the credentials hash because the default OAuth2 strategy supplied in the OmniAuth 1.0 gem only sets the following:

```
credentials do
    hash = {'token' => access_token.token}
    hash.merge!('refresh_token' => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
    hash.merge!('expires_at' => access_token.expires_at) if access_token.expires?
    hash.merge!('expires' => access_token.expires?)
    hash
end
```
