### PR TITLE
Add tests and validate salesforce user id using signature

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use 1.9.2-p290@omniauth-salesforce --create

--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -1,4 +1,6 @@
 require 'omniauth-oauth2'
+require 'openssl'
+require 'base64'
 
 module OmniAuth
   module Strategies
@@ -26,6 +28,15 @@ module OmniAuth
           mobile_request = ua.downcase =~ Regexp.new(MOBILE_USER_AGENTS)
           options[:display] = mobile_request ? 'touch' : 'page'
         end
+        super
+      end
+
+      def auth_hash
+        signed_value = access_token.params['id'] + access_token.params['issued_at']
+        raw_expected_signature = OpenSSL::HMAC.digest('sha256', options.client_secret, signed_value)
+        expected_signature = Base64.strict_encode64 raw_expected_signature
+        signature = access_token.params['signature']
+        fail! "Salesforce user id did not match signature!" unless signature == expected_signature
         super
       end
 

--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -4,7 +4,7 @@ module OmniAuth
   module Strategies
     class Salesforce < OmniAuth::Strategies::OAuth2
 
-      MOBILE_USER_AGENTS =  'webos|ipod|iphone|mobile'
+      MOBILE_USER_AGENTS =  'webos|ipod|iphone|ipad|android|blackberry|mobile'
 
       option :client_options, {
         :site          => 'https://login.salesforce.com',

--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -62,7 +62,9 @@ module OmniAuth
       extra do
         raw_info.merge({
           'instance_url' => access_token.params['instance_url'],
-          'pod' => access_token.params['instance_url']
+          'pod' => access_token.params['instance_url'],
+          'signature' => access_token.params['signature'],
+          'issued_at' => access_token.params['issued_at']
         })
       end
       

--- a/spec/omniauth/strategies/salesforce_spec.rb
+++ b/spec/omniauth/strategies/salesforce_spec.rb
@@ -1,7 +1,175 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Salesforce do
-  it 'should do some testing' do
-    pending
-  end
+	strategy = nil
+	before do
+		OmniAuth.config.test_mode = true
+		rack_app = []
+		rack_app.stub :call
+		strategy = OmniAuth::Strategies::Salesforce.new rack_app
+	end
+	describe "request_phase" do
+		env = nil
+		before do
+			env = {
+			'rack.session' => [], 
+			'HTTP_USER_AGENT' => 'unknown',
+			'REQUEST_METHOD' => 'GET',
+			'rack.input' => '',
+			'rack.url_scheme' => 'http',
+			'SERVER_NAME' => 'server.example', 
+			'QUERY_STRING' => 'code=xxxx', 
+			'SCRIPT_NAME' => '', 
+			'SERVER_PORT' => 80
+			}
+		end
+		context "when using a mobile browser" do
+			user_agents = {
+				:Pre => "Mozilla/5.0 (webOS/1.4.0; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.1",
+				:iPod => "Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A93 Safari/419.3",
+				:iPhone => "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3",
+				:iPad => "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10",
+				:Nexus => "Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+				:myTouch => "Mozilla/5.0 (Linux; U; Android 1.6; en-us; WOWMobile myTouch 3G Build/unknown) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1",
+				:Storm => "BlackBerry9530/4.7.0.148 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/105",
+				:Torch => "Mozilla/5.0 (BlackBerry; U; BlackBerry 9810; en-US) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0 Mobile Safari/534.11+",
+				:generic_mobile => "some mobile device"
+			}
+			user_agents.each_pair do |name, agent|
+				context "with the user agent from a #{name.to_s}" do
+					before do
+						env['HTTP_USER_AGENT'] = agent
+						strategy.call!(env)
+						strategy.request_phase
+					end
+					subject {strategy.options}
+					it "sets the :display option to 'touch'" do
+						subject[:display].should == 'touch'
+					end
+				end
+			end
+		end
+		context "when using a desktop browser" do
+			user_agents = {
+				:Chrome => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.21 (KHTML, like Gecko) Chrome/19.0.1042.0 Safari/535.21",
+				:Safari => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
+				:IE => "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 1.0.3705; .NET CLR 1.1.4322)",
+				:anything_else => "unknown"
+			}
+			user_agents.each_pair do |name, agent|
+				context "with the user agent from #{name.to_s}" do
+					before do
+						env['HTTP_USER_AGENT'] = agent
+						strategy.call!(env)
+						strategy.request_phase
+					end
+					subject {strategy.options}
+					it "sets the :display option to 'page'" do
+						subject[:display].should == 'page'
+					end
+				end
+			end
+		end
+	end
+	describe "callback phase" do
+		raw_info = nil
+		before do
+			raw_info = {
+				'id' => 'salesforce id',
+				'display_name' => 'display name',
+				'email' => 'email',
+				'nick_name' => 'nick name',
+				'first_name' => 'first name',
+				'last_name' => 'last name',
+				'photos' => {'thumbnail' => '/thumbnail/url'},
+				'urls'=> {
+					"enterprise" => "https://salesforce.example/services",
+					"metadata" => "https://salesforce.example/services"
+				}
+			}
+			client = OAuth2::Client.new 'id', 'secret', {:site => 'example.com'}
+			access_token = OAuth2::AccessToken.from_hash client, {
+				'access_token' => 'token',
+				'instance_url' => 'http://instance.salesforce.example'
+			}
+			strategy.stub(:raw_info) { raw_info }
+			strategy.stub(:access_token) { access_token }
+		end
+		describe "uid" do
+			it "sets the id" do
+				strategy.uid.should == raw_info['id']
+			end
+		end
+		describe "info" do
+			subject { strategy.info }
+			it "returns an info hash" do
+				subject.should_not be_nil
+			end
+			it "sets name" do 
+				subject['name'].should == raw_info['display_name']
+			end
+			it "sets email" do
+				subject['email'].should == raw_info['email']
+			end
+			it "sets nickname" do
+				subject['nickname'].should == raw_info['nick_name']
+			end
+			it "sets first_name" do
+				subject['first_name'].should == raw_info['first_name']
+			end
+			it "sets last_name" do
+				subject['last_name'].should == raw_info['last_name']
+			end
+			it "sets location" do
+				subject['location'].should == ''
+			end
+			it "sets description" do
+				subject['description'].should == ''
+			end
+			it "sets image" do
+				subject['image'].should == raw_info['photos']['thumbnail'] + "?oauth_token=#{strategy.access_token.token}"
+			end
+			it "sets phone" do
+				subject['phone'].should == ''
+			end
+			it "sets urls" do
+				subject['urls'].should == raw_info['urls']
+			end
+		end
+		describe "credentials" do
+			subject { strategy.credentials }
+			it "sets token" do 
+				subject['token'].should == strategy.access_token.token
+			end
+			it "sets instance_url" do
+				subject['instance_url'].should == strategy.access_token.params["instance_url"]
+			end
+			context "given a refresh token" do
+				it "sets refresh_token" do
+					subject['refresh_token'].should == strategy.access_token.refresh_token
+				end
+			end
+			context "when not given a refresh token" do
+				it "does not set a refresh token" do
+					subject['refresh_token'].should be_nil
+				end
+			end
+		end
+		describe "extra" do
+			subject { strategy.extra }
+			it "sets instance_url" do
+				subject['instance_url'].should == strategy.access_token.params['instance_url']
+			end
+			it "sets pod" do
+				subject['pod'].should == strategy.access_token.params['instance_url']
+			end
+			it "sets signature"
+			it "sets issued_at"
+		end
+		describe "callback_phase" do
+			context "when the signature does not match" do
+				it "should call fail!"
+			end
+		end
+	end
 end

--- a/spec/omniauth/strategies/salesforce_spec.rb
+++ b/spec/omniauth/strategies/salesforce_spec.rb
@@ -90,7 +90,9 @@ describe OmniAuth::Strategies::Salesforce do
 			client = OAuth2::Client.new 'id', 'secret', {:site => 'example.com'}
 			access_token = OAuth2::AccessToken.from_hash client, {
 				'access_token' => 'token',
-				'instance_url' => 'http://instance.salesforce.example'
+				'instance_url' => 'http://instance.salesforce.example',
+				'signature' => '',
+				'issued_at' => ''
 			}
 			strategy.stub(:raw_info) { raw_info }
 			strategy.stub(:access_token) { access_token }
@@ -163,12 +165,19 @@ describe OmniAuth::Strategies::Salesforce do
 			it "sets pod" do
 				subject['pod'].should == strategy.access_token.params['instance_url']
 			end
-			it "sets signature"
-			it "sets issued_at"
+			it "sets signature" do
+				subject['signature'].should == strategy.access_token.params['signature']
+			end
+			it "sets issued_at" do
+				subject['issued_at'].should == strategy.access_token.params['issued_at']
+			end
 		end
-		describe "callback_phase" do
+		describe "user id validation" do
 			context "when the signature does not match" do
-				it "should call fail!"
+				it "should call fail!" do
+					strategy.callback_phase
+					strategy.should_receive(:fail!)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Built out specs to try to capture existing behavior.

Added validation of the provided user id using the signature field returned by Salesforce. With the client application posting an authorization code over a https connection such a check is probably unnecessary for most applications.

> signature
> Base64-encoded HMAC-SHA256 signature signed with the consumer's private key containing the concatenated ID and issued_at. This can be used to verify the identity URL was not modified since it was sent by the server.
> From http://wiki.developerforce.com/page/Digging_Deeper_into_OAuth_2.0_at_Salesforce.com
